### PR TITLE
Fixes for Blog.Accounts.create_user/1

### DIFF
--- a/lib/blog/accounts/accounts.ex
+++ b/lib/blog/accounts/accounts.ex
@@ -13,6 +13,9 @@ defmodule Blog.Accounts do
       with {:ok, contact} <- create_contact(contact_attrs),
            {:ok, user} <- do_create_user(user_attrs, contact) do
         %{user | contacts: [contact]}
+      else
+        {:error, changeset} ->
+          Repo.rollback(changeset)
       end
     end
 
@@ -21,14 +24,14 @@ defmodule Blog.Accounts do
   def create_contact(attrs) do
     attrs
     |> Accounts.Contact.changeset
-    |> Blog.Repo.insert
+    |> Repo.insert
   end
 
   defp do_create_user(attrs, contact) do
     attrs
     |> Map.put(:contact_id, contact.id)
     |> Accounts.User.changeset
-    |> Blog.Repo.insert
+    |> Repo.insert
   end
 
 end

--- a/lib/blog/accounts/contact.ex
+++ b/lib/blog/accounts/contact.ex
@@ -24,6 +24,7 @@ defmodule Blog.Accounts.Contact do
     contact
     |> cast(attrs, [:type, :value])
     |> validate_required([:type, :value])
+    |> unique_constraint(:value, name: :contacts_type_value_index)
   end
 
 end

--- a/test/blog/accounts/accounts_test.exs
+++ b/test/blog/accounts/accounts_test.exs
@@ -15,4 +15,13 @@ defmodule Blog.AccountsTest do
     assert {:error, %Ecto.Changeset{}} = Accounts.create_user(attrs)
     assert ^contact_count = Repo.aggregate(Accounts.Contact, :count, :id)
   end
+
+  test "create_user/1 discards duplicate contacts" do
+    contact = %{type: "phone", value: "+1 000 000 0000"}
+
+    assert {:ok, _} = Accounts.create_user(%{contact: contact, name: "name", password: "password"})
+
+    assert {:error, changeset} = Accounts.create_user(%{contact: contact, name: "other", password: "password"})
+    assert "has already been taken" in errors_on(changeset).value
+  end
 end

--- a/test/blog/accounts/accounts_test.exs
+++ b/test/blog/accounts/accounts_test.exs
@@ -1,0 +1,18 @@
+defmodule Blog.AccountsTest do
+  use Blog.DataCase
+
+  alias Blog.Accounts
+
+  test "create_user/1 returns {:error, changeset} and rolles back transaction on error" do
+    attrs = %{
+      contact: %{type: "phone", value: "+1 000 000 0000"},
+      name: "",
+      password: "password"
+    }
+
+    contact_count = Repo.aggregate(Accounts.Contact, :count, :id)
+
+    assert {:error, %Ecto.Changeset{}} = Accounts.create_user(attrs)
+    assert ^contact_count = Repo.aggregate(Accounts.Contact, :count, :id)
+  end
+end


### PR DESCRIPTION
## Fix transaction in `Blog.Accounts.create_user/1`

If `Blog.Accounts.create_user/1` is provided with data which doesn't pass the validations in `Blog.Account.{User,Contact}.changeset/2`, the lambda function passed to `Ecto.Repo.transaction/2` will return `{error, %Ecto.Changeset{valid?: false}}`. This will not automatically roll back the transaction, as transaction are rolled back only if an error is raised, [as mentioned in the docs](https://hexdocs.pm/ecto/Ecto.Repo.html#c:transaction/2):

> If an unhandled error occurs the transaction will be rolled back and the error will bubble up from the transaction function. If no error occurred the transaction will be committed when the function returns. A transaction can be explicitly rolled back by calling `rollback/1`, this will immediately leave the function and return the value given to rollback as `{:error, value}`

Not only it results in stale records in the database, it messes the return value of `Blog.Accounts.create_user/1` as well. Because `Ecto.Repo.transaction/2` returns the value returned by the function wrapped in a tuple as `{:ok, value}`, in case of validation errors it will return `{:ok, {:error, %Ecto.Changeset{valid?: false}}}`.

To fix both issues, we need to match on `{:error, changeset}` and manually roll back the transaction.

## Validate uniqueness of `(type, value)` for the `contacts` table

`contacts` table has a unique constraint on `(type, value)`. If the user tries to insert the same contact twice, an error will be raised.